### PR TITLE
Main group 28 tela principal receitas

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,7 @@ import DetalhesBebida from './pages/DetalhesBebidas';
 import DetalhesReceita from './pages/DetalhesReceita';
 import ProcessoBebida from './pages/ProcessoBebida';
 import ProcessoReceita from './pages/ProcessoReceita';
+import NotFound from './pages/NotFound';
 
 function App() {
   return (
@@ -103,6 +104,7 @@ function App() {
             path="/bebidas/:id/in-progress"
             component={ ProcessoBebida }
           />
+          <Route component={ NotFound } />
         </Switch>
       </Provider>
     </div>

--- a/src/components/CardsDrink.jsx
+++ b/src/components/CardsDrink.jsx
@@ -10,14 +10,14 @@ function CardsFood() {
 
   const { cardDrink, setCardDrink } = useContext(CoffeeAndCodeContext);
 
-  useEffect(() => {
-    if (!cardDrink.length) callApi();
-  }, []);
-
   const callApi = async () => {
     const apiResult = await requestApiDrinkFilterName();
     setCardDrink(apiResult);
   };
+
+  useEffect(() => {
+    if (!cardDrink.length) callApi();
+  }, []);
 
   if (!cardDrink.length) return <span>Loading...</span>;
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice
@@ -56,7 +56,7 @@ function CardsFood() {
       <button
         type="button"
         onClick={ () => setCardAmount(cardAmount + maxCardAmount) }
-        disabled={ cardDrink.length > cardAmount ? false : true }
+        disabled={ cardDrink.length < cardAmount }
       >
         See More
       </button>

--- a/src/components/CardsDrink.jsx
+++ b/src/components/CardsDrink.jsx
@@ -26,7 +26,6 @@ function CardsFood() {
       {
         cardDrink.slice(firstCard, cardAmount)
           .map((currentObject, index) => {
-            console.log(currentObject)
             const {
               idDrink,
               strDrink,
@@ -56,6 +55,8 @@ function CardsFood() {
       }
       <button
         type="button"
+        onClick={ () => setCardAmount(cardAmount + maxCardAmount) }
+        disabled={ cardDrink.length > cardAmount ? false : true }
       >
         See More
       </button>

--- a/src/components/CardsDrink.jsx
+++ b/src/components/CardsDrink.jsx
@@ -1,0 +1,66 @@
+import React, { useState, useContext, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import CoffeeAndCodeContext from '../context/CoffeeAndCodeContext';
+import { requestApiDrinkFilterName } from '../services/requestDrink';
+
+function CardsFood() {
+  const maxCardAmount = 12;
+  const firstCard = 0;
+  const [cardAmount, setCardAmount] = useState(maxCardAmount);
+
+  const { cardDrink, setCardDrink } = useContext(CoffeeAndCodeContext);
+
+  useEffect(() => {
+    if (!cardDrink.length) callApi();
+  }, []);
+
+  const callApi = async () => {
+    const apiResult = await requestApiDrinkFilterName();
+    setCardDrink(apiResult);
+  };
+
+  if (!cardDrink.length) return <span>Loading...</span>;
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice
+  return (
+    <div>
+      {
+        cardDrink.slice(firstCard, cardAmount)
+          .map((currentObject, index) => {
+            console.log(currentObject)
+            const {
+              idDrink,
+              strDrink,
+              strDrinkThumb,
+            } = currentObject;
+
+            return (
+              <div
+                key={ idDrink }
+                data-testid={ `${index}-recipe-card` }
+              >
+                <Link to={ `/comidas/${idDrink}` }>
+                  <img
+                    src={ strDrinkThumb }
+                    alt={ strDrink }
+                    data-testid={ `${index}-card-img` }
+                  />
+                </Link>
+                <div>
+                  <Link to={ `/comidas/${idDrink}` }>
+                    <h4 data-testid={ `${index}-card-name` }>{ strDrink }</h4>
+                  </Link>
+                </div>
+              </div>
+            );
+          })
+      }
+      <button
+        type="button"
+      >
+        See More
+      </button>
+    </div>
+  );
+}
+
+export default CardsFood;

--- a/src/components/CardsFood.jsx
+++ b/src/components/CardsFood.jsx
@@ -1,0 +1,65 @@
+import React, { useState, useContext, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import CoffeeAndCodeContext from '../context/CoffeeAndCodeContext';
+import { requestApiFoodFilterName } from '../services/requestFood';
+
+function CardsFood() {
+  const maxCardAmount = 12;
+  const firstCard = 0;
+  const [cardAmount, setCardAmount] = useState(maxCardAmount);
+
+  const { cardFood, setCardFood } = useContext(CoffeeAndCodeContext);
+
+  useEffect(() => {
+    if (!cardFood.length) callApi();
+  }, []);
+
+  const callApi = async () => {
+    const apiResult = await requestApiFoodFilterName();
+    setCardFood(apiResult);
+  };
+
+  if (!cardFood.length) return <span>Loading...</span>;
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice
+  return (
+    <div>
+      {
+        cardFood.slice(firstCard, cardAmount)
+          .map((currentObject, index) => {
+            const {
+              idMeal,
+              strMeal,
+              strMealThumb,
+            } = currentObject;
+
+            return (
+              <div
+                key={ idMeal }
+                data-testid={ `${index}-recipe-card` }
+              >
+                <Link to={ `/comidas/${idMeal}` }>
+                  <img
+                    src={ strMealThumb }
+                    alt={ strMeal }
+                    data-testid={ `${index}-card-img` }
+                  />
+                </Link>
+                <div>
+                  <Link to={ `/comidas/${idMeal}` }>
+                    <h4 data-testid={ `${index}-card-name` }>{ strMeal }</h4>
+                  </Link>
+                </div>
+              </div>
+            );
+          })
+      }
+      <button
+        type="button"
+      >
+        See More
+      </button>
+    </div>
+  );
+}
+
+export default CardsFood;

--- a/src/components/CardsFood.jsx
+++ b/src/components/CardsFood.jsx
@@ -55,6 +55,8 @@ function CardsFood() {
       }
       <button
         type="button"
+        onClick={ () => setCardAmount(cardAmount + maxCardAmount) }
+        disabled={ cardFood.length >  cardAmount ? false : true }
       >
         See More
       </button>

--- a/src/components/CardsFood.jsx
+++ b/src/components/CardsFood.jsx
@@ -10,14 +10,14 @@ function CardsFood() {
 
   const { cardFood, setCardFood } = useContext(CoffeeAndCodeContext);
 
-  useEffect(() => {
-    if (!cardFood.length) callApi();
-  }, []);
-
   const callApi = async () => {
     const apiResult = await requestApiFoodFilterName();
     setCardFood(apiResult);
   };
+
+  useEffect(() => {
+    if (!cardFood.length) callApi();
+  }, []);
 
   if (!cardFood.length) return <span>Loading...</span>;
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice
@@ -56,7 +56,7 @@ function CardsFood() {
       <button
         type="button"
         onClick={ () => setCardAmount(cardAmount + maxCardAmount) }
-        disabled={ cardFood.length >  cardAmount ? false : true }
+        disabled={ cardFood.length < cardAmount }
       >
         See More
       </button>

--- a/src/pages/Bebidas.jsx
+++ b/src/pages/Bebidas.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
-import CardsDrink from '../components/CardsDrink'
+import CardsDrink from '../components/CardsDrink';
 
 function Bebidas() {
   return (

--- a/src/pages/Bebidas.jsx
+++ b/src/pages/Bebidas.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
+import CardsDrink from '../components/CardsDrink'
 
 function Bebidas() {
   return (
     <div>
       <Header name="Bebidas" button />
+      <CardsDrink />
       <Footer />
     </div>
   );

--- a/src/pages/Comidas.jsx
+++ b/src/pages/Comidas.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import Header from '../components/Header';
 import Footer from '../components/Footer';
+import CardsFood from '../components/CardsFood';
 
 function Comidas() {
   return (
     <div>
       <Header name="Comidas" button />
+      <CardsFood />
       <Footer />
     </div>
   );

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const NotFound = () => (
+  <div>
+    <h1>404 - Not Found!</h1>
+    <Link to="/">
+      Go Home
+    </Link>
+  </div>
+);
+
+export default NotFound;


### PR DESCRIPTION
### O que foi feito

- Requisição API na página de comidas e bebidas para carregar receitas;
- Mostra apenas 12 cards;
- Os cards contém imagem e título;
- A imagem e o título redirecionam para detalhes da receita;
- Adicionados os data-testids
- Implementação do botão para carregar mais 12 sempre que for clicado;
- Desabilita o botão quando não ter mais receitas para serem carregadas;
- Criação do page NotFound;
- Criação da rota NotFound;
- Estruturação da page NotFound;
_**Os testes não foram feitos**_